### PR TITLE
Fix module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note: This project is under active development and is not intended to be used in
 go get github.com/pietdaniel/ddmon
 
 # Install a specific version
-go get github.com/pietdaniel/ddmon@v0.0.2
+go get github.com/pietdaniel/ddmon@v0.0.3
 ```
 
 ## Usage

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ var rootCmd = &cobra.Command{
 	Long: `Given many common monitor patterns, ddmon aids in generating terraform
 files for Datadog by providing a rich templating language built off sprig and terse
 YAML monitor definitions to generate terraform Datadog monitors.`,
-	Version: "0.0.2",
+	Version: "0.0.3",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DataDog/ddmon
+module github.com/pietdaniel/ddmon
 
 go 1.15
 


### PR DESCRIPTION
My local directory structure caused an incorrect path in `go.mod` which caused an installation failure:

```sh
> go get github.com/pietdaniel/ddmon@v0.0.2

go get: github.com/pietdaniel/ddmon@v0.0.2: parsing go.mod:
	module declares its path as: github.com/DataDog/ddmon
	        but was required as: github.com/pietdaniel/ddmon
```

 This PR correct the path and updates version references.