### PR TITLE
Update module installation instructions and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note: This project is under active development and is not intended to be used in
 go get github.com/pietdaniel/ddmon
 
 # Install a specific version
-go get github.com/pietdaniel/ddmon@v0.0.3
+GO111MODULE=on go get github.com/pietdaniel/ddmon@v0.0.4
 ```
 
 ## Usage

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ var rootCmd = &cobra.Command{
 	Long: `Given many common monitor patterns, ddmon aids in generating terraform
 files for Datadog by providing a rich templating language built off sprig and terse
 YAML monitor definitions to generate terraform Datadog monitors.`,
-	Version: "0.0.3",
+	Version: "0.0.4",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.4.0 // indirect
-	github.com/pietdaniel/ddmon v0.0.0-20191023143245-e50372cc6523
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect


### PR DESCRIPTION
In order to install a specific version of a module when you have `GOPATH` set, you have to enable modules with `GO111MODULE=on` or else you get this error:

```sh
> go get github.com/pietdaniel/ddmon@v0.0.3
go: cannot use path@version syntax in GOPATH mode
```

Also, the fix for the module path in `go.mod` from #5 changed the dependencies, so this includes that update as well.