### PR TITLE
bug: checkForTplFile checks wrong dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5] - 2020-09-24
+### Fixed
+- bug: checkForTplFile checks wrong dir #7
+
 ## [0.0.4] - 2020-09-24
 ### Changed
 - Update module installation instructions and dependencies #6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4] - 2020-09-24
+### Changed
+- Update module installation instructions and dependencies #6
+
+## [0.0.3] - 2019-09-24
+### Changed
+- Convert ddmon to go module #4
+
+## [0.0.2] - 2019-09-24
+### Fixed
+- Fix module path (#5)
 
 ## [0.0.1] - 2019-10-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note: This project is under active development and is not intended to be used in
 go get github.com/pietdaniel/ddmon
 
 # Install a specific version
-GO111MODULE=on go get github.com/pietdaniel/ddmon@v0.0.4
+GO111MODULE=on go get github.com/pietdaniel/ddmon@v0.0.5
 ```
 
 ## Usage

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ var rootCmd = &cobra.Command{
 	Long: `Given many common monitor patterns, ddmon aids in generating terraform
 files for Datadog by providing a rich templating language built off sprig and terse
 YAML monitor definitions to generate terraform Datadog monitors.`,
-	Version: "0.0.4",
+	Version: "0.0.5",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/lib/generate.go
+++ b/lib/generate.go
@@ -105,7 +105,7 @@ func getListOfTemplates(templateDir, monitor, group, namespace string) []string 
 }
 
 func checkForTplFile(name string, sourceDir string) (string, bool) {
-	tplFilePath := fmt.Sprintf("%s/templates/%s.tpl", sourceDir, name)
+	tplFilePath := fmt.Sprintf("%s/%s.tpl", sourceDir, name)
 	_, err := os.Stat(tplFilePath)
 	if err != nil {
 		log.Printf("Could not find template %s", tplFilePath)

--- a/lib/render.go
+++ b/lib/render.go
@@ -37,7 +37,7 @@ func render(tplPaths, dataPaths []string, filename, outputPath string) {
 	}
 
 	if err := t.Execute(f, data); err != nil {
-		log.Printf("Failed to render template: %v %v", tplPaths, dataPaths)
+		log.Printf("Failed to render template: %v %v %s", tplPaths, dataPaths, err)
 	}
 	// todo extract to function
 


### PR DESCRIPTION
Ran into this issue trying to create a $GROUP.tpl which wasn't getting picked up. Also, adds rendering errors to the log message for more troubleshooting.

What I expected:
```
a = "base.tpl"
b = "mygrp.tpl"
```

What I got:
```
a = "base.tpl"
b = "default.tpl"
```



Script to reproduce:
```
set -x
go install github.com/pietdaniel/ddmon@942bb4c

mkdir monitors
pushd monitors

mkdir output
mkdir --parents resources/templates
echo 'a = "base.tpl"' > resources/templates/base.tpl
echo 'b = "default.tpl"' > resources/templates/default.tpl
echo 'b = "mygrp.tpl"' > resources/templates/mygrp.tpl

mkdir --parents monitors/data/myns/mygrp
touch monitors/data/common.yaml
touch monitors/data/myns/common.yaml
touch monitors/data/myns/mygrp/common.yaml
touch monitors/data/myns/mygrp/mymonitor.yaml

ddmon generate --source-dir ./monitors --target-dir ./output --template-dir ./resources/templates
cat output/mygrp-mymonitor.tf
popd
rm -r monitors
```
